### PR TITLE
Add LiquidatorData entity for liquidation leaderboard tracking

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -49,7 +49,7 @@ type Morpho_Liquidate {
 type GeneralizedLiquidation {
   id: ID!
   chainId: Int!
-  timestamp: BigInt!
+  timestamp: BigInt! @index
   protocol: String!
   borrower: String!
   liquidator: String!
@@ -67,4 +67,17 @@ type LiquidationStats {
   eulerCount: BigInt!
   morphoCount: BigInt!
   totalCount: BigInt!
+}
+
+type LiquidatorData {
+  id: ID!
+  liquidator: String!
+  chainId: Int
+  aaveLiquidations: BigInt!
+  eulerLiquidations: BigInt!
+  morphoLiquidations: BigInt!
+  totalLiquidations: BigInt!
+  liquidations: [String!]!
+  firstLiquidationTimestamp: BigInt
+  lastLiquidationTimestamp: BigInt
 }

--- a/src/EventHandlers.ts
+++ b/src/EventHandlers.ts
@@ -13,6 +13,7 @@ import {
   GeneralizedLiquidation,
   LiquidationStats,
 } from "generated";
+import { updateLiquidatorData } from "./helpers";
 
 AaveProxy.LiquidationCall.handler(async ({ event, context }) => {
   const entity: AaveProxy_LiquidationCall = {
@@ -44,6 +45,16 @@ AaveProxy.LiquidationCall.handler(async ({ event, context }) => {
     seizedAssets: event.params.liquidatedCollateralAmount,
   };
   context.GeneralizedLiquidation.set(generalized);
+
+  // Update liquidator data
+  await updateLiquidatorData(
+    context,
+    event.params.liquidator,
+    event.chainId,
+    "Aave",
+    generalized.id,
+    BigInt(event.block.timestamp)
+  );
 
   // Update per-chain stats
   const perChainStatsId = `stats_${event.chainId}`;
@@ -119,6 +130,16 @@ EulerVaultProxy.Liquidate.handler(async ({ event, context }) => {
   };
   context.GeneralizedLiquidation.set(generalized);
 
+  // Update liquidator data
+  await updateLiquidatorData(
+    context,
+    event.params.liquidator,
+    event.chainId,
+    "Euler",
+    generalized.id,
+    BigInt(event.block.timestamp)
+  );
+
   // Update per-chain stats
   const perChainStatsId2 = `stats_${event.chainId}`;
   const existingPerChain2 = await context.LiquidationStats.get(
@@ -179,6 +200,16 @@ Morpho.Liquidate.handler(async ({ event, context }) => {
     seizedAssets: event.params.seizedAssets,
   };
   context.GeneralizedLiquidation.set(generalized);
+
+  // Update liquidator data
+  await updateLiquidatorData(
+    context,
+    event.params.caller,
+    event.chainId,
+    "Morpho",
+    generalized.id,
+    BigInt(event.block.timestamp)
+  );
 
   // Update per-chain stats
   const perChainStatsId3 = `stats_${event.chainId}`;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,35 @@
+import { LiquidatorData } from "generated";
+
+// Helper function to update liquidator data
+export async function updateLiquidatorData(
+  context: any,
+  liquidator: string,
+  chainId: number,
+  protocol: "Aave" | "Euler" | "Morpho",
+  liquidationId: string,
+  timestamp: bigint
+) {
+  const liquidatorId = `${liquidator}_${chainId}`;
+  const existing = await context.LiquidatorData.get(liquidatorId);
+
+  const liquidatorData: LiquidatorData = {
+    id: liquidatorId,
+    liquidator: liquidator,
+    chainId: chainId,
+    aaveLiquidations:
+      BigInt(existing?.aaveLiquidations ?? 0n) +
+      (protocol === "Aave" ? 1n : 0n),
+    eulerLiquidations:
+      BigInt(existing?.eulerLiquidations ?? 0n) +
+      (protocol === "Euler" ? 1n : 0n),
+    morphoLiquidations:
+      BigInt(existing?.morphoLiquidations ?? 0n) +
+      (protocol === "Morpho" ? 1n : 0n),
+    totalLiquidations: BigInt(existing?.totalLiquidations ?? 0n) + 1n,
+    liquidations: [...(existing?.liquidations ?? []), liquidationId],
+    firstLiquidationTimestamp: existing?.firstLiquidationTimestamp ?? timestamp,
+    lastLiquidationTimestamp: timestamp,
+  };
+
+  context.LiquidatorData.set(liquidatorData);
+}


### PR DESCRIPTION
- Add LiquidatorData schema with liquidator statistics and liquidation IDs array
- Create helpers.ts with updateLiquidatorData function for tracking liquidator stats
- Update all liquidation handlers (Aave, Euler, Morpho) to track liquidator data
- Track per-protocol liquidation counts, total liquidations, and timestamps
- Store array of liquidation IDs for each liquidator for detailed querying
- Add timestamp index to GeneralizedLiquidation for better query performance